### PR TITLE
feat: Add days of month option and enhance stats page

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,11 @@
+targets:
+  $default:
+    builders:
+      hive_generator:
+        options:
+          build_extensions:
+            .dart: .g.dart
+      source_gen|combining_builder:
+        options:
+          build_extensions:
+            .dart: .iconfig.dart

--- a/lib/screens/add_edit_goal_screen.dart
+++ b/lib/screens/add_edit_goal_screen.dart
@@ -40,7 +40,8 @@ class _AddEditGoalScreenState extends State<AddEditGoalScreen> {
 
     final goalProvider = Provider.of<GoalProvider>(context, listen: false);
     List<int> frequencyValue = [];
-    if (_frequencyType == FrequencyType.daysOfWeek) {
+    if (_frequencyType == FrequencyType.daysOfWeek ||
+        _frequencyType == FrequencyType.daysOfMonth) {
       frequencyValue = _selectedDays;
     }
 
@@ -69,6 +70,30 @@ class _AddEditGoalScreenState extends State<AddEditGoalScreen> {
                 _selectedDays.add(index + 1);
               } else {
                 _selectedDays.removeWhere((int day) => day == index + 1);
+              }
+              _selectedDays.sort();
+            });
+          },
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildMonthDaySelector() {
+    return Wrap(
+      spacing: 8.0,
+      runSpacing: 4.0,
+      children: List<Widget>.generate(31, (int index) {
+        final day = index + 1;
+        return FilterChip(
+          label: Text('$day'),
+          selected: _selectedDays.contains(day),
+          onSelected: (bool selected) {
+            setState(() {
+              if (selected) {
+                _selectedDays.add(day);
+              } else {
+                _selectedDays.removeWhere((int d) => d == day);
               }
               _selectedDays.sort();
             });
@@ -122,6 +147,7 @@ class _AddEditGoalScreenState extends State<AddEditGoalScreen> {
                 onChanged: (FrequencyType? newValue) {
                   setState(() {
                     _frequencyType = newValue!;
+                    _selectedDays.clear();
                   });
                 },
               ),
@@ -130,7 +156,11 @@ class _AddEditGoalScreenState extends State<AddEditGoalScreen> {
                 const Text('Select Days'),
                 _buildDaySelector(),
               ],
-              // TODO: Add UI for daysOfMonth
+              if (_frequencyType == FrequencyType.daysOfMonth) ...[
+                const SizedBox(height: 16),
+                const Text('Select Days of Month'),
+                _buildMonthDaySelector(),
+              ],
             ],
           ),
         ),

--- a/lib/screens/stats_page.dart
+++ b/lib/screens/stats_page.dart
@@ -1,5 +1,8 @@
+import 'package:everyday/models/goal.dart';
 import 'package:everyday/providers/goal_provider.dart';
+import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class StatsPage extends StatelessWidget {
@@ -37,11 +40,19 @@ class StatsPage extends StatelessWidget {
                         ),
                       ),
                       const SizedBox(height: 16),
-                      Text('Total Completions: ${goal.totalCompletions}'),
-                      const SizedBox(height: 8),
-                      Text('Current Streak: ${goal.currentStreak} days'),
-                      const SizedBox(height: 8),
-                      Text('Longest Streak: ${goal.longestStreak} days'),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        children: [
+                          _buildStatItem('Total', goal.totalCompletions),
+                          _buildStatItem('Current Streak', goal.currentStreak),
+                          _buildStatItem('Longest Streak', goal.longestStreak),
+                        ],
+                      ),
+                      const SizedBox(height: 24),
+                      SizedBox(
+                        height: 200,
+                        child: _CompletionHeatmap(goal: goal),
+                      ),
                     ],
                   ),
                 ),
@@ -49,6 +60,80 @@ class StatsPage extends StatelessWidget {
             },
           );
         },
+      ),
+    );
+  }
+
+  Widget _buildStatItem(String label, int value) {
+    return Column(
+      children: [
+        Text(
+          '$value',
+          style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 4),
+        Text(label, style: const TextStyle(fontSize: 12, color: Colors.grey)),
+      ],
+    );
+  }
+}
+
+class _CompletionHeatmap extends StatelessWidget {
+  final Goal goal;
+
+  const _CompletionHeatmap({Key? key, required this.goal}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final completions = goal.completions.map((c) => DateTime(c.year, c.month, c.day)).toSet();
+    final now = DateTime.now();
+    final oneYearAgo = now.subtract(const Duration(days: 365));
+    final data = <DateTime, int>{};
+
+    for (int i = 0; i <= now.difference(oneYearAgo).inDays; i++) {
+      final date = oneYearAgo.add(Duration(days: i));
+      final dateOnly = DateTime(date.year, date.month, date.day);
+      if (completions.contains(dateOnly)) {
+        data[dateOnly] = 1;
+      } else {
+        data[dateOnly] = 0;
+      }
+    }
+
+    return BarChart(
+      BarChartData(
+        alignment: BarChartAlignment.spaceAround,
+        barTouchData: BarTouchData(
+          touchTooltipData: BarTouchTooltipData(
+            getTooltipItem: (group, groupIndex, rod, rodIndex) {
+              final date = oneYearAgo.add(Duration(days: groupIndex));
+              final formattedDate = DateFormat.yMMMd().format(date);
+              final status = rod.toY > 0 ? 'Completed' : 'Not Completed';
+              return BarTooltipItem(
+                '$formattedDate\n$status',
+                const TextStyle(color: Colors.white),
+              );
+            },
+          ),
+        ),
+        titlesData: const FlTitlesData(show: false),
+        borderData: FlBorderData(show: false),
+        gridData: const FlGridData(show: false),
+        barGroups: data.entries.map((entry) {
+          final x = data.keys.toList().indexOf(entry.key);
+          final y = entry.value.toDouble();
+          return BarChartGroupData(
+            x: x,
+            barRods: [
+              BarChartRodData(
+                toY: y,
+                color: y > 0 ? Colors.green : Colors.grey[300],
+                width: 5,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ],
+          );
+        }).toList(),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,8 @@ dependencies:
   provider: ^6.0.5
   path_provider: ^2.0.11
   shared_preferences: ^2.0.15
+  fl_chart: ^0.68.0
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This commit introduces two major enhancements to the goal tracking functionality:

- **Days of Month Frequency:** Users can now select specific days of the month for their goals. A new UI component with a grid of selectable day chips has been added to the add/edit goal screen.

- **Enhanced Statistics Page:** The statistics page has been redesigned for better data visualization. It now features a heatmap for each goal, displaying completion history over the past year. Key stats such as total completions, current streak, and longest streak are now presented in a more organized and visually appealing layout.

The `fl_chart` and `intl` packages have been added to support these new features.